### PR TITLE
hotfix/TOPS-800: Renaming gsoft-inc organization to workleap in github.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
 
   linearb:
     needs: [ci]
-    uses: gsoft-inc/wl-reusable-workflows/.github/workflows/linearb-deployment.yml@main
+    uses: workleap/wl-reusable-workflows/.github/workflows/linearb-deployment.yml@main
     with:
       environment: development
     secrets: inherit

--- a/.github/workflows/jira.yml
+++ b/.github/workflows/jira.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   call-workflow-jira:
-    uses: gsoft-inc/wl-reusable-workflows/.github/workflows/reusable-jira-workflow.yml@main
+    uses: workleap/wl-reusable-workflows/.github/workflows/reusable-jira-workflow.yml@main
     with:
       branch_name: ${{ github.head_ref }}
     secrets: inherit

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ jobs:
 
   linearb:
     needs: [publish]
-    uses: gsoft-inc/wl-reusable-workflows/.github/workflows/linearb-deployment.yml@main
+    uses: workleap/wl-reusable-workflows/.github/workflows/linearb-deployment.yml@main
     with:
       environment: 'release'
     secrets: inherit

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -12,4 +12,4 @@ jobs:
     permissions:
       contents: read
       security-events: write
-    uses: gsoft-inc/wl-reusable-workflows/.github/workflows/reusable-semgrep-workflow.yml@main
+    uses: workleap/wl-reusable-workflows/.github/workflows/reusable-semgrep-workflow.yml@main

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Workleap.DomainEventPropagation
 
-[![build](https://img.shields.io/github/actions/workflow/status/gsoft-inc/workleap-domain-event-propagation/publish.yml?logo=github&branch=main)](https://github.com/gsoft-inc/workleap-domain-event-propagation/actions/workflows/publish.yml)
+[![build](https://img.shields.io/github/actions/workflow/status/gsoft-inc/workleap-domain-event-propagation/publish.yml?logo=github&branch=main)](https://github.com/workleap/workleap-domain-event-propagation/actions/workflows/publish.yml)
 
 | Package                                                          | Download Link                                                                                                                                                                                                               | Description                                                                                 |
 |------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------|
@@ -343,5 +343,5 @@ To learn more about configuring or suppressing code analysis warnings, refer to 
 
 ## License
 
-Copyright © 2023, Workleap This code is licensed under the Apache License, Version 2.0. You may obtain a copy of this license at https://github.com/gsoft-inc/gsoft-license/blob/master/LICENSE.
+Copyright © 2023, Workleap This code is licensed under the Apache License, Version 2.0. You may obtain a copy of this license at https://github.com/workleap/gsoft-license/blob/master/LICENSE.
 

--- a/src/Workleap.DomainEventPropagation.Analyzers/AnalyzerReleases.Shipped.md
+++ b/src/Workleap.DomainEventPropagation.Analyzers/AnalyzerReleases.Shipped.md
@@ -4,6 +4,6 @@
 
 Rule ID | Category | Severity | Notes
 --------|----------|----------|--------------------
-WLDEP01 | Usage    | Warning  | EventDomainAttributeUsageAnalyzer, [Documentation](https://github.com/gsoft-inc/wl-domain-event-propagation)
-WLDEP02 | Usage    | Warning  | UseUniqueNameForAttributeValue, [Documentation](https://github.com/gsoft-inc/wl-domain-event-propagation)
-WLDEP03 | Usage    | Warning  | FollowNamingConventionAttributeValue, [Documentation](https://github.com/gsoft-inc/wl-domain-event-propagation)
+WLDEP01 | Usage    | Warning  | EventDomainAttributeUsageAnalyzer, [Documentation](https://github.com/workleap/wl-domain-event-propagation)
+WLDEP02 | Usage    | Warning  | UseUniqueNameForAttributeValue, [Documentation](https://github.com/workleap/wl-domain-event-propagation)
+WLDEP03 | Usage    | Warning  | FollowNamingConventionAttributeValue, [Documentation](https://github.com/workleap/wl-domain-event-propagation)

--- a/src/Workleap.DomainEventPropagation.Analyzers/Internals/RuleIdentifiers.cs
+++ b/src/Workleap.DomainEventPropagation.Analyzers/Internals/RuleIdentifiers.cs
@@ -2,7 +2,7 @@ namespace Workleap.DomainEventPropagation.Analyzers.Internals;
 
 internal static class RuleIdentifiers
 {
-    public const string HelpUri = "https://github.com/gsoft-inc/wl-domain-event-propagation";
+    public const string HelpUri = "https://github.com/workleap/wl-domain-event-propagation";
 
     // DO NOT change the identifier of existing rules.
     // Projects can customize the severity level of analysis rules using a .editorconfig file.


### PR DESCRIPTION
TOPS-800: Replacing gsoft-inc/wl-reusable-workflows by workleap/wl-reusable-workflows

--
Not sure why this PR has been created? Reach TechOps in our public slack channel: #techops-and-friends
Some context on the why of this PR can be found here: https://workleap.slack.com/archives/C02E9KPRQ7P/p1737385211295479 