### PR TITLE
Bubble up exceptions happening when handling events

### DIFF
--- a/src/Workleap.DomainEventPropagation.Subscription.PullDelivery/EventPullerService.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription.PullDelivery/EventPullerService.cs
@@ -97,10 +97,10 @@ internal sealed class EventPullerService : BackgroundService
         public async Task StartReceivingEventsAsync(CancellationToken cancellationToken)
         {
             // Use a local cancellation token source to allow stopping the events reception/processing if a callback task crashes
-            var cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            using var cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 
             // Start the tasks that will process events and handle the completion callback
-            var eventProcessingTasks = new List<Task>
+            var eventProcessingTasks = new []
                 {
                     this.ProcessEvents(cancellationTokenSource.Token),
                     this.AcknowledgeEvents(cancellationToken),

--- a/src/Workleap.DomainEventPropagation.Subscription.PullDelivery/EventPullerService.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription.PullDelivery/EventPullerService.cs
@@ -115,9 +115,9 @@ internal sealed class EventPullerService : BackgroundService
             Task[] eventProcessingTasks =
             [
                 this.ProcessEvents(cancellationTokenSource.Token),
-                    this.AcknowledgeEvents(cancellationToken),
-                    this.ReleaseEvents(cancellationToken),
-                    this.RejectEvents(cancellationToken)
+                this.AcknowledgeEvents(cancellationToken),
+                this.ReleaseEvents(cancellationToken),
+                this.RejectEvents(cancellationToken)
             ];
 
             await Task.WhenAny(eventProcessingTasks).ConfigureAwait(false);

--- a/src/Workleap.DomainEventPropagation.Subscription.PullDelivery/EventPullerService.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription.PullDelivery/EventPullerService.cs
@@ -100,13 +100,13 @@ internal sealed class EventPullerService : BackgroundService
             using var cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 
             // Start the tasks that will process events and handle the completion callback
-            var eventProcessingTasks = new []
-                {
-                    this.ProcessEvents(cancellationTokenSource.Token),
+            Task[] eventProcessingTasks =
+            [
+                this.ProcessEvents(cancellationTokenSource.Token),
                     this.AcknowledgeEvents(cancellationToken),
                     this.ReleaseEvents(cancellationToken),
                     this.RejectEvents(cancellationToken)
-                };
+            ];
 
             await Task.WhenAny(eventProcessingTasks).ConfigureAwait(false);
 


### PR DESCRIPTION
## Description of changes
Using Task.WhenAll() will wait until every task is in a completed state before returning. This is problematic when a single subscription crashes, as we would normally expect the exception to bubble up to the IHost and crash it, thus enabling the entire app to be restarted, but it's not happening as long as at least one subscription hasn't crashed out.

This replaces Task.WhenAll() with a system that immediately bubbles up the first exception encountered.

## Breaking changes
In theory, a pod that was running this background service would survive a crash in a subscription as long as any other subscription didn't crash. With this change, the pod is expected to crash entirely, enabling k8s to detect the broken state and restart it.

## Additional checks
- [x] Added new tests that cover the code changes
