### PR TITLE
[IDP-3177] Manually bump version to address Dependabot interference

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Workleap.DotNet.CodingStandards" Version="1.0.2">
+    <PackageReference Include="Workleap.DotNet.CodingStandards" Version="1.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/src/Workleap.DomainEventPropagation.Analyzers.Tests/Workleap.DomainEventPropagation.Analyzers.Tests.csproj
+++ b/src/Workleap.DomainEventPropagation.Analyzers.Tests/Workleap.DomainEventPropagation.Analyzers.Tests.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.2" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.11.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.13.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="Polly" Version="8.5.2" />
     <PackageReference Include="xunit" Version="2.9.3" />

--- a/src/Workleap.DomainEventPropagation.Publishing.ApplicationInsights/Workleap.DomainEventPropagation.Publishing.ApplicationInsights.csproj
+++ b/src/Workleap.DomainEventPropagation.Publishing.ApplicationInsights/Workleap.DomainEventPropagation.Publishing.ApplicationInsights.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.22.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.23.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Workleap.DomainEventPropagation.Publishing/Workleap.DomainEventPropagation.Publishing.csproj
+++ b/src/Workleap.DomainEventPropagation.Publishing/Workleap.DomainEventPropagation.Publishing.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.2" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.2" />
-    <PackageReference Include="OpenTelemetry.Api" Version="1.11.1" />
+    <PackageReference Include="OpenTelemetry.Api" Version="1.11.2" />
     <PackageReference Include="System.Text.Json" Version="9.0.2" />
   </ItemGroup>
 

--- a/src/Workleap.DomainEventPropagation.Subscription.ApplicationInsights/Workleap.DomainEventPropagation.Subscription.ApplicationInsights.csproj
+++ b/src/Workleap.DomainEventPropagation.Subscription.ApplicationInsights/Workleap.DomainEventPropagation.Subscription.ApplicationInsights.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.22.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.23.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Workleap.DomainEventPropagation.Subscription.PullDelivery.Tests/Workleap.DomainEventPropagation.Subscription.PullDelivery.Tests.csproj
+++ b/src/Workleap.DomainEventPropagation.Subscription.PullDelivery.Tests/Workleap.DomainEventPropagation.Subscription.PullDelivery.Tests.csproj
@@ -8,13 +8,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CliWrap" Version="3.8.1" />
+    <PackageReference Include="CliWrap" Version="3.8.2" />
     <PackageReference Include="FakeItEasy" Version="8.3.0" />
     <PackageReference Include="GSoft.Extensions.Xunit" Version="1.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.13" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="OpenTelemetry" Version="1.11.1" />
-    <PackageReference Include="Testcontainers" Version="4.1.0" />
+    <PackageReference Include="OpenTelemetry" Version="1.11.2" />
+    <PackageReference Include="Testcontainers" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Workleap.DomainEventPropagation.Subscription.PullDelivery/Workleap.DomainEventPropagation.Subscription.PullDelivery.csproj
+++ b/src/Workleap.DomainEventPropagation.Subscription.PullDelivery/Workleap.DomainEventPropagation.Subscription.PullDelivery.csproj
@@ -26,7 +26,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="OpenTelemetry.Api" Version="1.11.1" />
+    <PackageReference Include="OpenTelemetry.Api" Version="1.11.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Workleap.DomainEventPropagation.Subscription.Tests/Workleap.DomainEventPropagation.Subscription.Tests.csproj
+++ b/src/Workleap.DomainEventPropagation.Subscription.Tests/Workleap.DomainEventPropagation.Subscription.Tests.csproj
@@ -14,13 +14,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CliWrap" Version="3.8.1" />
+    <PackageReference Include="CliWrap" Version="3.8.2" />
     <PackageReference Include="FakeItEasy" Version="8.3.0" />
     <PackageReference Include="GSoft.Extensions.Xunit" Version="1.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.13" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="OpenTelemetry" Version="1.11.1" />
-    <PackageReference Include="Testcontainers" Version="4.1.0" />
+    <PackageReference Include="OpenTelemetry" Version="1.11.2" />
+    <PackageReference Include="Testcontainers" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Workleap.DomainEventPropagation.Subscription/Workleap.DomainEventPropagation.Subscription.csproj
+++ b/src/Workleap.DomainEventPropagation.Subscription/Workleap.DomainEventPropagation.Subscription.csproj
@@ -22,7 +22,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="OpenTelemetry.Api" Version="1.11.1" />
+    <PackageReference Include="OpenTelemetry.Api" Version="1.11.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Description of changes

Had to manually bump all packages version. Here's why.

All PRs but one failed due to a vulnerability. This vulnerability update was covered in a PR opened by Dependabot (wtf) and not Renovate. Dependabot's PR was failing Jira branch name, of course.

Instead of dealing with individual PRs, I created a single one to fix everything in one shot.

## Breaking changes
N/A

## Additional checks
Create a patch release after merge.

- [ ] Updated the documentation of the project to reflect the changes
- [ ] Added new tests that cover the code changes
