### PR TITLE
Added ingestion controls to EventPullerService

### DIFF
--- a/src/Workleap.DomainEventPropagation.Subscription.PullDelivery/EventPropagationSubscriptionOptions.cs
+++ b/src/Workleap.DomainEventPropagation.Subscription.PullDelivery/EventPropagationSubscriptionOptions.cs
@@ -24,4 +24,14 @@ public class EventPropagationSubscriptionOptions
     public int MaxRetries { get; set; } = 3;
 
     public IReadOnlyCollection<TimeSpan>? RetryDelays { get; set; }
+
+    /// <summary>
+    /// Maximum number of events to pull from Event Grid per poll.
+    /// </summary>
+    public int MaxPullBatchSize { get; set; } = 100;
+
+    /// <summary>
+    /// Interval to wait between polling for new events.
+    /// </summary>
+    public TimeSpan PullInterval { get; set; } = TimeSpan.Zero;
 }


### PR DESCRIPTION
## Description of changes
Added MaxPullBatchSize to EventPropagationSubscriptionOptions:

- Controls how many events are fetched in a single call to ReceiveCloudEventsAsync.

Added PullInterval to EventPropagationSubscriptionOptions:

- Enforces a delay between pull attempts to prevent overloading consumers.

## Breaking changes
None, all changes are backward-compatible.

## Additional checks
- [ ] Updated the documentation of the project to reflect the changes
- [X] Added new tests that cover the code changes
