### PR TITLE
Add Cortex deployment tracker

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,6 +48,7 @@ jobs:
     uses: workleap/wl-reusable-workflows/.github/workflows/linearb-deployment.yml@main
     with:
       environment: 'release'
+      cortexEntityIdOrTag: service-wl-domain-event-propagation
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
Jira issue link: [feng-722](https://workleap.atlassian.net/browse/feng-722)

This pull request updates the GitHub Actions workflow configuration to include a new parameter for deployment.

Workflow configuration update:

* [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7R51): Added the `cortexEntityIdOrTag` parameter with the value `service-wl-domain-event-propagation` to the `linearb-deployment.yml` reusable workflow to specify the associated Cortex entity or tag.